### PR TITLE
SR武将突破

### DIFF
--- a/character/jlsg_skpf.js
+++ b/character/jlsg_skpf.js
@@ -334,7 +334,7 @@ export default {
 			locked: false,
 			trigger: { target: "useCardToTargeted" },
 			filter(event, player) {
-				return event.player != player && event.card && (event.card.name == "sha" || get.type(event.card) == "trick");
+				return event.player != player && event.card && (event.card.name == "sha" || get.type(event.card) == "trick") && player.getCards("h").some(card => get.color(card) == "black");
 			},
 			async cost(event, trigger, player) {
 				event.result = await player
@@ -350,6 +350,8 @@ export default {
 						}
 						return eff + eff2 - get.value(card);
 					})
+					.set("filterCard", card => get.color(card) == "black")
+					.set("position", "h")
 					.set("cardx", trigger.card)
 					.set("target", trigger.player)
 					.set("chooseonly", true)

--- a/character/jlsg_soul.js
+++ b/character/jlsg_soul.js
@@ -1008,9 +1008,7 @@ export default {
 				let characterList;
 				if (lib.config.extension_极略_jlsgsoul_sp_zhugeliang == "false") {
 					if (!_status.characterlist) {
-						//PR判断致敬我自己给本体修的bug（  ——zhonghui1966
-						if (lib.skill.lihun2.onremove) game.initCharacterList();
-						else game.initCharactertList();
+						game.initCharactertList();
 					}
 					characterList = _status.characterlist.slice().randomSort();
 				} else {
@@ -1156,8 +1154,7 @@ export default {
 				let characterList;
 				if (lib.config.extension_极略_jlsgsoul_sp_zhugeliang == "false") {
 					if (!_status.characterlist) {
-						if (lib.skill.lihun2.onremove) game.initCharacterList();
-						else game.initCharactertList();
+						game.initCharactertList();
 					}
 					characterList = _status.characterlist.slice().randomSort();
 				} else {
@@ -3669,8 +3666,7 @@ export default {
 			content: function () {
 				"step 0"
 				if (!_status.characterlist) {
-					if (lib.skill.lihun2.onremove) game.initCharacterList();
-					else game.initCharactertList();
+					game.initCharactertList();
 				}
 				_status.characterlist.randomSort();
 				var list = [];
@@ -4355,8 +4351,7 @@ export default {
 			audio: "ext:极略/audio/skill:2",
 			initList: function () {
 				if (!_status.characterlist) {
-					if (lib.skill.lihun2.onremove) game.initCharacterList();
-					else game.initCharactertList();
+					game.initCharactertList();
 				}
 				_status.jlsg_luocha_list = [];
 				_status.jlsg_luocha_list_hidden = [];
@@ -8922,8 +8917,7 @@ export default {
 							content: async function (event, trigger, player) {
 								let group = player.group;
 								if (!_status.characterlist) {
-									if (lib.skill.lihun2.onremove) game.initCharacterList();
-									else game.initCharactertList();
+									game.initCharactertList();
 								}
 								let allList = _status.characterlist.slice(0).randomSort();
 								for (let name of allList) {

--- a/character/jlsg_sr.js
+++ b/character/jlsg_sr.js
@@ -43,26 +43,26 @@ export default {
 				if (get.itemtype(player) != "player") {
 					return false;
 				}
-				const names = get.nameList(player);
+				const nameList = get.nameList(player);
 				for (const name of names) {
 					if (name.indexOf("jlsgsr_") == 0) {
 						return true;
 					}
 				}
-				return false;
+				return nameList.some(name => name.startsWith("jlsgsr_"));
 			},
 			forced: true,
 			popup: false,
 			async content(event, trigger, player) {
-				const nameList = get.nameList(player);
+				const nameList = get.nameList(player),
+					upgradeList = lib.config.extension_极略_upgradeList || [];
 				for (const name of nameList) {
-					if (!name.startsWith("jlsgsr_") || !(name in get.info("_jlsgsr_choice").upgradeContent)) {
+					if (!name.startsWith("jlsgsr_")) {
 						continue;
 					}
-					let nameStr = "extension_极略_" + name;
-					if (lib.config?.[nameStr] == "false") {
+					if (upgradeList.includes(name)) {
 						if (_status._jlsgsr_upgrade?.[player.playerid]?.[name]) {
-							break;
+							continue;
 						}
 						let info = [false, false, false, false],
 							choiceList = [...Object.keys(lib.skill[event.name].upgradeContent[name]), "技能突破", "携带所有技能"];

--- a/character/jlsg_sr.js
+++ b/character/jlsg_sr.js
@@ -66,6 +66,10 @@ export default {
 						}
 						let info = [false, false, false, false],
 							choiceList = [...Object.keys(lib.skill[event.name].upgradeContent[name]), "技能突破", "携带所有技能"];
+						if (!lib.config.extension_极略_srlose) {
+							info = info.slice(1, -1);
+							choiceList = choiceList.slice(0, -1);
+						}
 						//非强制突破，非顺次选择
 						const { result: upgrade } = await player
 							.chooseButton([1, 4], [`请选择${get.translation(name)}的突破`, [choiceList.map((item, i) => [i, item]), "textbutton"]])
@@ -156,7 +160,7 @@ export default {
 				const list = [];
 				const info = get.character(name);
 				if (info) {
-					const skills = info[3];
+					const skills = info.skills;
 					for (const skill of skills) {
 						let infox = get.info(skill);
 						if (lib.translate[skill + "_info"] && infox.srlose) {

--- a/character/jlsg_zhu.js
+++ b/character/jlsg_zhu.js
@@ -474,7 +474,7 @@ export default {
 			trigger: { global: "damageEnd" },
 			filter(event, player) {
 				if (!get.itemtype(event.cards) == "cards") return false;
-				if (!event.cards.somInD("od")) {
+				if (!event.cards.someInD("od")) {
 					return false;
 				}
 				if (!event.source || event.source == player || event.player?.isIn() || event.player == player) {

--- a/character/oldCharacter/jlsg_sr.js
+++ b/character/oldCharacter/jlsg_sr.js
@@ -12,7 +12,7 @@ export default {
 					},
 					direct: true,
 					content: function () {
-						"step 0"
+						"step 0";
 						if (trigger.player.inRangeOf(player)) {
 							var next = player.chooseBool(get.prompt("jlsg_zhaoxiang", trigger.player));
 							next.ai = function () {
@@ -32,7 +32,7 @@ export default {
 							};
 							next.logSkill = ["jlsg_zhaoxiang", trigger.player];
 						}
-						"step 1"
+						("step 1");
 						if (result.bool) {
 							if (!result.cards) {
 								player.logSkill("jlsg_zhaoxiang", trigger.player);
@@ -55,7 +55,7 @@ export default {
 						} else {
 							event.finish();
 						}
-						"step 2"
+						("step 2");
 						if (!result.bool) {
 							trigger.untrigger();
 							trigger.finish();
@@ -85,7 +85,7 @@ export default {
 					discard: false,
 					lose: false,
 					content: function () {
-						"step 0"
+						"step 0";
 						player.showCards(cards[0]);
 						var nono = false;
 						if (ai.get.damageEffect(target, player, player)) nono = true;
@@ -109,11 +109,11 @@ export default {
 								})
 								.set("nono", nono);
 						}
-						"step 1"
+						("step 1");
 						if (cards[0].name == "shan" && result.cards) {
 							target.showCards(result.cards[0]);
 						}
-						"step 2"
+						("step 2");
 						if (result.bool) {
 							player.recover();
 							target.recover();
@@ -138,7 +138,6 @@ export default {
 			},
 			translate: {
 				jlsg_zhaoxiang_info: "当一名其他角色使用【杀】指定目标后，你可以令其选择一项：1、交给你一张牌。2、令此【杀】对该目标无效；若其或【杀】的目标在你的攻击范围内，你须先弃置一张手牌。",
-
 				jlsg_zhishi_info: "出牌阶段限一次，你可以指定一名有手牌的其他角色，你选择其中一项执行：1.你展示一张【杀】令其弃置一张【杀】，若其执行，你与其恢复1点体力，否则你对其造成1点伤害；2.你展示一张【闪】令其弃置一张【闪】，若其执行，你与其恢复1点体力，否则你对其造成1点伤害。",
 			},
 		},
@@ -153,7 +152,7 @@ export default {
 					},
 					direct: true,
 					content: function () {
-						"step 0"
+						"step 0";
 						if (trigger.player.inRangeOf(player)) {
 							var next = player.chooseBool(get.prompt("jlsg_zhaoxiang", trigger.player));
 							next.ai = function () {
@@ -173,7 +172,7 @@ export default {
 							};
 							next.logSkill = ["jlsg_zhaoxiang", trigger.player];
 						}
-						"step 1"
+						("step 1");
 						if (result.bool) {
 							if (!result.cards) {
 								player.logSkill("jlsg_zhaoxiang", trigger.player);
@@ -196,7 +195,7 @@ export default {
 						} else {
 							event.finish();
 						}
-						"step 2"
+						("step 2");
 						if (!result.bool) {
 							trigger.untrigger();
 							trigger.finish();
@@ -217,7 +216,7 @@ export default {
 						return player != target;
 					},
 					content: function () {
-						"step 0"
+						"step 0";
 						if (!target.countDiscardableCards(target, "h")) {
 							target.damage(player);
 							target.recover();
@@ -229,7 +228,7 @@ export default {
 							if (get.recoverEffect(target, target, target) > 0) return 7.5 - get.value(card);
 							return -1;
 						};
-						"step 1"
+						("step 1");
 						if (result.bool) {
 							target.recover();
 						} else {
@@ -256,6 +255,226 @@ export default {
 			translate: {
 				jlsg_zhaoxiang_info: "当一名其他角色使用【杀】指定目标后，你可以令其选择一项：1、交给你一张牌。2、令此【杀】对该目标无效；若其或【杀】的目标在你的攻击范围内，你须先弃置一张手牌。",
 				jlsg_zhishi_info: "出牌阶段限一次，你可以令一名其他角色选择一项：1、弃置一张基本牌，然后回复一点体力。2、受到你造成的一点伤害，然后回复一点体力。",
+			},
+		},
+		3: {
+			skill: {
+				jlsg_zhaoxiang: {
+					audio: "ext:极略/audio/skill:1",
+					trigger: { global: "useCardToPlayer" },
+					filter(event, player) {
+						if (event.card.name != "sha") {
+							return false;
+						} else if (event.player == player) {
+							return false;
+						}
+						return event.player.countGainableCards(player, "h");
+					},
+					async cost(event, trigger, player) {
+						event.result = await player
+							.gainPlayerCard(get.prompt2("jlsg_zhaoxiang", trigger.player), trigger.player, "h")
+							.set("ai", button => {
+								if (get.event("check")) return get.event().getRand(button.link.cardid.toString());
+								return 0;
+							})
+							.set(
+								"check",
+								(function () {
+									const gainEff = get.effect(trigger.player, { name: "shunshou_copy2" }, player, player),
+										shaEff1 = get.effect(trigger.player, trigger.card, trigger.target, player),
+										shaEff2 = get.effect(trigger.player, trigger.card, player, player);
+									return gainEff + shaEff1 > 0 || gainEff + shaEff2 > 0;
+								})()
+							)
+							.set("logSkill", ["jlsg_zhaoxiang", trigger.player])
+							.set("chooseonly", true)
+							.forResult();
+						if (event.result?.bool) {
+							event.result.skill_popup = false;
+							event.result.targets = [trigger.player];
+						}
+					},
+					async content(event, trigger, player) {
+						const {
+							cards,
+							targets: [target],
+						} = event;
+						await player.gain(cards, target, "bySelf").set("ainimate", false);
+						const { result } = await player
+							.chooseControlList("招降", ["令此【杀】不能被响应", "将此【杀】的目标改为你"], true)
+							.set("ai", () => get.event("choice"))
+							.set(
+								"choice",
+								(function () {
+									const shaEff1 = get.effect(trigger.player, trigger.card, trigger.target, player),
+										shaEff2 = get.effect(trigger.player, trigger.card, player, player);
+									if (shaEff1 > shaEff2) {
+										return 0;
+									}
+									return 1;
+								})()
+							);
+						if (result?.index == 0) {
+							game.log(player, "令", trigger.card, "不能被响应");
+							trigger.getParent().directHit.addArray(game.players);
+						} else if (result?.index == 1) {
+							game.log(player, "将", trigger.card, "的目标", trigger.target, "改为", player);
+							trigger.targets.remove(trigger.target);
+							trigger.targets.add(player);
+							trigger.getParent().triggeredTargets1.remove(trigger.target);
+							trigger.getParent().triggeredTargets1.add(player);
+							trigger.getParent().targets.remove(trigger.target);
+							trigger.getParent().targets.add(player);
+						}
+					},
+					ai: {
+						expose: 0.5,
+					},
+				},
+				jlsg_zhishi: {
+					audio: "ext:极略/audio/skill:2",
+					trigger: { global: "damageEnd" },
+					filter(event, player) {
+						return event.num > 0 && event.player.isIn();
+					},
+					prompt(event, player) {
+						return get.prompt("jlsg_zhishi", event.player);
+					},
+					prompt2: "令其从你拥有的随机两个能在此时机发动的技能中选择一个并发动",
+					check(event, player) {
+						return get.attitude(player, event.player) > 0;
+					},
+					logTarget: "player",
+					async content(event, trigger, player) {
+						if (!_status.characterlist) {
+							game.initCharactertList();
+						}
+						const allList = _status.characterlist.slice(0);
+						game.countPlayer(function (current) {
+							const nameList = get.nameList(current);
+							nameList.forEach(name => {
+								if (lib.character[name] && name.indexOf("gz_shibing") != 0 && name.indexOf("gz_jun_") != 0) {
+									allList.add(name);
+								}
+							});
+						});
+						const skills = [];
+						allList.randomSort();
+						for (const name of allList) {
+							if (name.indexOf("zuoci") != -1 || name.indexOf("xushao") != -1) continue;
+							const skills2 = get.character(name).skills || [];
+							for (const skill of skills2) {
+								if (skills.includes(skill)) {
+									continue;
+								}
+								const list = [skill];
+								game.expandSkills(list);
+								for (const skill2 of list) {
+									const info = lib.skill[skill2];
+									if (get.is.zhuanhuanji(skill2, trigger.player)) continue;
+									if (!info || !info.trigger || !info.trigger.player || info.silent || info.limited || info.juexingji || info.hiddenSkill || info.dutySkill || (info.zhuSkill && !trigger.player.isZhu2())) {
+										continue;
+									}
+									if (info.trigger.player == "damageEnd" || (Array.isArray(info.trigger.player) && info.trigger.player.includes("damageEnd"))) {
+										if (info.ai && ((info.ai.combo && !trigger.player.hasSkill(info.ai.combo)) || info.ai.notemp || info.ai.neg)) continue;
+										if (info.init) continue;
+										if (info.filter) {
+											let indexedData;
+											if (typeof info.getIndex === "function") {
+												indexedData = info.getIndex(trigger, trigger.player, "damageEnd");
+												if (Array.isArray(indexedData)) {
+													if (
+														!indexedData.some(target => {
+															try {
+																const bool = info.filter(trigger, trigger.player, "damageEnd", target);
+																if (bool) return true;
+																return false;
+															} catch (e) {
+																return false;
+															}
+														})
+													) {
+														continue;
+													}
+												} else if (typeof indexedData === "number" && indexedData > 0) {
+													try {
+														const bool = info.filter(trigger, trigger.player, "damageEnd", true);
+														if (!bool) continue;
+													} catch (e) {
+														continue;
+													}
+												}
+											} else {
+												try {
+													const bool = info.filter(trigger, trigger.player, "damageEnd", true);
+													if (!bool) continue;
+												} catch (e) {
+													continue;
+												}
+											}
+										}
+										skills.add(skill);
+										if (skills.length > 1) break;
+									}
+								}
+							}
+							if (skills.length > 1) break;
+						}
+						if (!skills.length) {
+							return;
+						}
+						const buttons = skills.map(i => [i, '<div class="popup pointerdiv" style="width:80%;display:inline-block"><div class="skill">【' + get.translation(i) + "】</div><div>" + lib.translate[i + "_info"] + "</div></div>"]);
+						const { result } = await trigger.player.chooseButton(true, ["选择要发动的技能", [buttons, "textbutton"]]).set("ai", button => get.skillRank(button.link, "out"));
+						if (!result?.bool) {
+							return;
+						}
+						const skill = result.links[0];
+						game.log(trigger.player, `选择了【${get.translation(skill)}】`);
+						trigger.player.addTempSkill(skill, { player: "damageAfter" });
+						const arrange = event.getParent("arrangeTrigger", true);
+						if (arrange) {
+							const { doingList, doing } = arrange;
+							const num1 = doingList.indexOf(doing),
+								num2 = doingList.findIndex(i => i.player == trigger.player);
+							//若目标角色在arrangeTrigger中顺序已过，则手动createTrigger
+							if (num1 > num2) {
+								const skills2 = game.expandSkills([skill]),
+									toadds = [];
+								for (let skill2 of skills2) {
+									const info = lib.skill[skill2];
+									if (typeof info.getIndex === "function") {
+										const indexedResult = info.getIndex(trigger, trigger.player, "damageEnd");
+										if (Array.isArray(indexedResult)) {
+											indexedResult.forEach(indexedData => {
+												toadds.push({ indexedData, skill2 });
+											});
+										} else if (typeof indexedResult === "number" && indexedResult > 0) {
+											for (let i = 0; i < indexedResult; i++) {
+												toadds.push({ indexedData: true, skill2 });
+											}
+										}
+									} else {
+										toadds.push({ indexedData: true, skill2 });
+									}
+								}
+								for (let i of toadds) {
+									const { indexedData, skill2 } = i;
+									if (lib.filter.filterTrigger(trigger, trigger.player, "damageEnd", skill2, indexedData)) {
+										await game.createTrigger("damageEnd", skill2, trigger.player, trigger, indexedData);
+									}
+								}
+							}
+						}
+					},
+					ai: {
+						maixue: true,
+						maixie_hp: true,
+					},
+				},
+			},
+			translate: {
+				jlsg_zhaoxiang_info: "当其他角色使用【杀】指定目标时，你可以获得其一张手牌，然后选择一项：1．令此【杀】不能被响应；2．将此【杀】的目标改为你。",
+				jlsg_zhishi_info: "当任意角色受到伤害后，你可以令其从随机两个能在此时机发动的技能中选择一个并发动。",
 			},
 		},
 	},

--- a/character/oldCharacter/jlsg_sr.js
+++ b/character/oldCharacter/jlsg_sr.js
@@ -12,7 +12,7 @@ export default {
 					},
 					direct: true,
 					content: function () {
-						"step 0";
+						"step 0"
 						if (trigger.player.inRangeOf(player)) {
 							var next = player.chooseBool(get.prompt("jlsg_zhaoxiang", trigger.player));
 							next.ai = function () {
@@ -32,7 +32,7 @@ export default {
 							};
 							next.logSkill = ["jlsg_zhaoxiang", trigger.player];
 						}
-						("step 1");
+						"step 1"
 						if (result.bool) {
 							if (!result.cards) {
 								player.logSkill("jlsg_zhaoxiang", trigger.player);
@@ -55,7 +55,7 @@ export default {
 						} else {
 							event.finish();
 						}
-						("step 2");
+						"step 2"
 						if (!result.bool) {
 							trigger.untrigger();
 							trigger.finish();
@@ -85,7 +85,7 @@ export default {
 					discard: false,
 					lose: false,
 					content: function () {
-						"step 0";
+						"step 0"
 						player.showCards(cards[0]);
 						var nono = false;
 						if (ai.get.damageEffect(target, player, player)) nono = true;
@@ -109,11 +109,11 @@ export default {
 								})
 								.set("nono", nono);
 						}
-						("step 1");
+						"step 1"
 						if (cards[0].name == "shan" && result.cards) {
 							target.showCards(result.cards[0]);
 						}
-						("step 2");
+						"step 2"
 						if (result.bool) {
 							player.recover();
 							target.recover();
@@ -152,7 +152,7 @@ export default {
 					},
 					direct: true,
 					content: function () {
-						"step 0";
+						"step 0"
 						if (trigger.player.inRangeOf(player)) {
 							var next = player.chooseBool(get.prompt("jlsg_zhaoxiang", trigger.player));
 							next.ai = function () {
@@ -172,7 +172,7 @@ export default {
 							};
 							next.logSkill = ["jlsg_zhaoxiang", trigger.player];
 						}
-						("step 1");
+						"step 1"
 						if (result.bool) {
 							if (!result.cards) {
 								player.logSkill("jlsg_zhaoxiang", trigger.player);
@@ -195,7 +195,7 @@ export default {
 						} else {
 							event.finish();
 						}
-						("step 2");
+						"step 2"
 						if (!result.bool) {
 							trigger.untrigger();
 							trigger.finish();
@@ -216,7 +216,7 @@ export default {
 						return player != target;
 					},
 					content: function () {
-						"step 0";
+						"step 0"
 						if (!target.countDiscardableCards(target, "h")) {
 							target.damage(player);
 							target.recover();
@@ -228,7 +228,7 @@ export default {
 							if (get.recoverEffect(target, target, target) > 0) return 7.5 - get.value(card);
 							return -1;
 						};
-						("step 1");
+						"step 1"
 						if (result.bool) {
 							target.recover();
 						} else {
@@ -485,7 +485,7 @@ export default {
 				jlsg_rende: {
 					audio: "ext:极略/audio/skill:1",
 					srlose: true,
-					trigger: { global: "phaseJieshuEnd" },
+					trigger: { global: "phaseJieshuBegin" },
 					filter(event, player) {
 						return player.countGainableCards(event.player, "h") && event.player.isAlive();
 					},

--- a/main/config.js
+++ b/main/config.js
@@ -63,10 +63,11 @@ let block = {
 					false: "最新",
 					1: "一代",
 					2: "二代",
+					3: "三代",
 				},
 				onclick(item) {
 					game.saveExtensionConfig("极略", "jlsgsr_caocao", item);
-					if ((item == "false" || Boolean(item) > 2) && !lib.config.extension_极略_upgradeList?.includes("jlsgsr_caocao")) {
+					if ((item == "false" || Boolean(item) >3) && !lib.config.extension_极略_upgradeList?.includes("jlsgsr_caocao")) {
 						let upgradeList = lib.config.extension_极略_upgradeList || [];
 						upgradeList.add("jlsgsr_caocao");
 						game.saveExtensionConfig("极略", "upgradeList", upgradeList);

--- a/main/config.js
+++ b/main/config.js
@@ -56,7 +56,7 @@ let block = {
 	oldCharacterReplace = {
 		sr: {
 			jlsgsr_caocao: {
-				jlsg_upgrade:true,
+				jlsg_upgrade: true,
 				name: "SR曹操",
 				init: "false",
 				item: {
@@ -112,7 +112,7 @@ let block = {
 				},
 			},
 			jlsgsr_liubei: {
-				jlsg_upgrade:true,
+				jlsg_upgrade: true,
 				name: "SR刘备",
 				init: "false",
 				item: {

--- a/main/config.js
+++ b/main/config.js
@@ -56,12 +56,27 @@ let block = {
 	oldCharacterReplace = {
 		sr: {
 			jlsgsr_caocao: {
+				jlsg_upgrade:true,
 				name: "SR曹操",
 				init: "false",
 				item: {
 					false: "最新",
 					1: "一代",
 					2: "二代",
+				},
+				onclick(item) {
+					game.saveExtensionConfig("极略", "jlsgsr_caocao", item);
+					if ((item == "false" || Boolean(item) > 2) && !lib.config.extension_极略_upgradeList?.includes("jlsgsr_caocao")) {
+						let upgradeList = lib.config.extension_极略_upgradeList || [];
+						upgradeList.add("jlsgsr_caocao");
+						game.saveExtensionConfig("极略", "upgradeList", upgradeList);
+					} else {
+						if (lib.config.extension_极略_upgradeList?.includes("jlsgsr_caocao")) {
+							let upgradeList = lib.config.extension_极略_upgradeList || [];
+							upgradeList.remove("jlsgsr_caocao");
+							game.saveExtensionConfig("极略", "upgradeList", upgradeList);
+						}
+					}
 				},
 			},
 			jlsgsr_guojia: {
@@ -94,6 +109,29 @@ let block = {
 				item: {
 					false: "最新",
 					1: "一代",
+				},
+			},
+			jlsgsr_liubei: {
+				jlsg_upgrade:true,
+				name: "SR刘备",
+				init: "false",
+				item: {
+					false: "最新",
+					1: "一代",
+				},
+				onclick(item) {
+					game.saveExtensionConfig("极略", "jlsgsr_liubei", item);
+					if ((item == "false" || Boolean(item) > 1) && !lib.config.extension_极略_upgradeList?.includes("jlsgsr_liubei")) {
+						let upgradeList = lib.config.extension_极略_upgradeList || [];
+						upgradeList.add("jlsgsr_liubei");
+						game.saveExtensionConfig("极略", "upgradeList", upgradeList);
+					} else {
+						if (lib.config.extension_极略_upgradeList?.includes("jlsgsr_liubei")) {
+							let upgradeList = lib.config.extension_极略_upgradeList || [];
+							upgradeList.remove("jlsgsr_liubei");
+							game.saveExtensionConfig("极略", "upgradeList", upgradeList);
+						}
+					}
 				},
 			},
 		},

--- a/main/content.js
+++ b/main/content.js
@@ -44,6 +44,8 @@ const b = 1;
 	} else {
 		game.saveConfig("extension_极略_wrongExtensionNameAlert", false);
 	}
+	//适配PR 换个写法（
+	if(get.info("lihun2").onremove) game.initCharactertList=game.initCharacterList;
 
 	//武将替换
 	const characterReplaceExclude = {

--- a/main/precontent.js
+++ b/main/precontent.js
@@ -1408,6 +1408,19 @@ export async function precontent(config, originalPack) {
 			return pack;
 		});
 	}
+	//SR武将突破初始列表
+	if (!lib.config.extension_极略_upgradeList) {
+		let upgradeList = [];
+		const configx = config.config;
+		for (let i in configx) {
+			if (!configx[i].jlsg_upgrade) {
+				continue;
+			} else {
+				upgradeList.add(i);
+			}
+		}
+		game.saveExtensionConfig("极略", "upgradeList", upgradeList);
+	}
 
 	let name = jlsg_qs.name;
 	game.import("card", function () {

--- a/main/precontent.js
+++ b/main/precontent.js
@@ -1409,17 +1409,13 @@ export async function precontent(config, originalPack) {
 		});
 	}
 	//SR武将突破初始列表
-	if (!lib.config.extension_极略_upgradeList) {
-		let upgradeList = [];
-		const configx = config.config;
-		for (let i in configx) {
-			if (!configx[i].jlsg_upgrade) {
-				continue;
-			} else {
-				upgradeList.add(i);
-			}
+	const configx = config.config;
+	for (let i in configx) {
+		if (!configx[i].jlsg_upgrade) {
+			continue;
+		} else {
+			configx[i].onclick(lib.config[`extension_极略_${i}`]);
 		}
-		game.saveExtensionConfig("极略", "upgradeList", upgradeList);
 	}
 
 	let name = jlsg_qs.name;

--- a/main/precontent.js
+++ b/main/precontent.js
@@ -1337,7 +1337,7 @@ export async function precontent(config, originalPack) {
 						for (let i of lib.skill._jlsg_buff.list) {
 							str += `<br><b style="color: green" onclick="jlsg.helpStr.skillStr(this, '` + i + `')">▶` + get.translation(i) + "</b>";
 						}
-						str = '<hr><li>极略主公buff：<br>极略的特殊机制，当极略武将作为主公时，可以从三个随机主公技中选择并获得一个（如果游戏为双将模式，则额外选择一个主公技）<br>神势力角色当主公时，所有其他角色均视为与其势力相同，神势力角色可以响应所有势力的主公的主公技（未完工）<br>详见：<a href="https://www.bilibili.com/opus/844481636614537270/?from=readlist">极略主公buff详情</a><br><li>极略主公技能一览：<br>' + str;
+						str = '<hr><li>极略主公buff：<br>极略的特殊机制，当极略武将作为主公时，可以从三个随机主公技中选择并获得一个（如果游戏为双将模式，则额外选择一个主公技）<br>神势力角色当主公时，所有其他角色均视为与其势力相同，神势力角色可以响应所有势力的主公的主公技<br>详见：<a href="https://www.bilibili.com/opus/844481636614537270/?from=readlist">极略主公buff详情</a><br><li>极略主公技能一览：<br>' + str;
 					}
 					var more = ui.create.div(
 						".hth_more",


### PR DESCRIPTION
1. 对扩展config内包含武将突破的选择加入`jlsg_upgrade`标签，并在扩展precontent部分初始化需要突破的武将列表`lib.config.extension_极略_upgradeList`；
2. 将”SR武将突破“的选择事件插入`_jlsgsr_choice`技能内部，存储形式如下
` _status_jlsgsr_upgrade: {`
`	"player.playerid": {`
`		武将id：[第一次突破, 第二次突破, 第三次突破(技能突破), 第四次突破(携带所有技能)],`
`               characterName: [false, false, false, false],`
`               默认全关`
`	},`
`}`
3. 新增全局技能`_jlsgsr_upgrade_effect`用以实现”前两次突破“的属性调整；
4. 突破武将（SR曹操、SR刘备）；
5. 各种bug修复（详见commits）